### PR TITLE
Change fyle app link from cluster domain to new app domain

### DIFF
--- a/.github/workflows/github-pipeline.yaml
+++ b/.github/workflows/github-pipeline.yaml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SECRET_KEY: thisisafakedjangosecretkey
+      FYLE_APP_URL: fakefyleappurl
       FYLE_CLIENT_ID: fakefyleclientid
       FYLE_CLIENT_SECRET: fakefyleclientsecret
       FYLE_ACCOUNTS_URL: fakefyleaccounturl

--- a/fyle_slack_app/fyle/utils.py
+++ b/fyle_slack_app/fyle/utils.py
@@ -86,11 +86,11 @@ def get_fyle_profile(refresh_token: str) -> Dict:
 
 
 def get_fyle_resource_url(fyle_refresh_token: str, resource: Dict, resource_type: str) -> str:
-    cluster_domain = get_cluster_domain(fyle_refresh_token)
-
+    fyle_app_url = settings.FYLE_APP_URL
+    
     RESOURCE_URL_MAPPING = {
-        'REPORT': '{}/app/main/#/enterprise/reports'.format(cluster_domain),
-        'EXPENSE': '{}/app/main/#/enterprise/view_expense'.format(cluster_domain)
+        'REPORT': '{}/app/main/#/enterprise/reports'.format(fyle_app_url),
+        'EXPENSE': '{}/app/main/#/enterprise/view_expense'.format(fyle_app_url)
     }
 
     resource_base_url = RESOURCE_URL_MAPPING[resource_type]

--- a/fyle_slack_app/slack/authorization/views.py
+++ b/fyle_slack_app/slack/authorization/views.py
@@ -20,7 +20,7 @@ class SlackAuthorization(View):
 
         error = request.GET.get('error')
 
-        # If any error occured redirecting to FyleHQ website
+        # If any error occurs, redirect to FyleHQ website
         if error:
 
             logger.error('Slack bot installation failed %s', error)

--- a/fyle_slack_app/slack/ui/notifications/messages.py
+++ b/fyle_slack_app/slack/ui/notifications/messages.py
@@ -333,7 +333,7 @@ def get_report_approver_sendback_notification(report: Dict, report_url: str, rep
 
 def get_report_submitted_notification(report: Dict, report_url: str) -> List[Dict]:
 
-    title_text = ':clipboard: Your expense report <{}|[{}]> has been submitted approval'.format(
+    title_text = ':clipboard: Your expense report <{}|[{}]> has been submitted for approval'.format(
                     report_url,
                     report['seq_num']
                 )

--- a/fyle_slack_service/settings.py
+++ b/fyle_slack_service/settings.py
@@ -219,6 +219,7 @@ LOGGING = {
 LOG_LEVEL = os.environ.get('LOGGING_LEVEL', 'DEBUG')
 
 # Fyle Settings
+FYLE_APP_URL = os.environ['FYLE_APP_URL']
 FYLE_ACCOUNTS_URL = os.environ['FYLE_ACCOUNTS_URL']
 FYLE_CLIENT_ID = os.environ['FYLE_CLIENT_ID']
 FYLE_CLIENT_SECRET = os.environ['FYLE_CLIENT_SECRET']


### PR DESCRIPTION
Tested the flow - 
1. Redirection from slack to fyle working fine
2. During redirection, if user is logged out, they are automatically redirected to (https://accounts.fyle.tech/app/router/#/signin)


*Note to Self* -
Before deploying the change, confirm with @shreyanshss7 if `FYLE_APP_URL` present in prod as env variable, is correct or not