### PR TITLE
Restrict slack user to have only one fyle account link

### DIFF
--- a/fyle_slack_app/fyle/authorization/views.py
+++ b/fyle_slack_app/fyle/authorization/views.py
@@ -63,7 +63,8 @@ class FyleAuthorization(View):
 
             if user is not None:
                 # If the user already exists, send a message to user indicating they've already linked Fyle account
-                self.send_linked_account_message(slack_client, slack_user_dm_channel_id)
+                message = 'Hey buddy you\'ve already linked your *Fyle* account :rainbow:'
+                self.send_linked_account_message(slack_client, slack_user_dm_channel_id, message)
 
             else:
                 fyle_refresh_token = fyle_utils.get_fyle_refresh_token(code)
@@ -76,7 +77,8 @@ class FyleAuthorization(View):
                     # If the fyle user already exists, send a message to user indicating they've already 
                     # linked their Fyle account in one of their slack workspace
                     team_name = fyle_user.slack_team.name
-                    self.send_linked_account_message(slack_client, slack_user_dm_channel_id, team_name)
+                    message = f'Hey buddy you\'ve already linked your *Fyle* account in this workspace `{team_name}` :rainbow:'
+                    self.send_linked_account_message(slack_client, slack_user_dm_channel_id, message)
                 
                 else:
                     # Putting below logic inside a transaction block to prevent bad data
@@ -130,12 +132,7 @@ class FyleAuthorization(View):
         )
 
 
-    def send_linked_account_message(self, slack_client: WebClient, slack_user_dm_channel_id: str, workspace_name: str = None) -> None:
-        if workspace_name is not None:
-            message = f'Hey buddy you\'ve already linked your *Fyle* account in this workspace `{workspace_name}` :rainbow:'
-        else:
-            message = 'Hey buddy you\'ve already linked your *Fyle* account :rainbow:'
-        
+    def send_linked_account_message(self, slack_client: WebClient, slack_user_dm_channel_id: str, message: str = None) -> None:
         slack_client.chat_postMessage(
             channel=slack_user_dm_channel_id,
             text=message

--- a/fyle_slack_app/fyle/authorization/views.py
+++ b/fyle_slack_app/fyle/authorization/views.py
@@ -76,8 +76,15 @@ class FyleAuthorization(View):
                 if fyle_user is not None:
                     # If the fyle user already exists, send a message to user indicating they've already 
                     # linked their Fyle account in one of their slack workspace
-                    team_name = fyle_user.slack_team.name
-                    message = f'Hey buddy you\'ve already linked your *Fyle* account in this workspace `{team_name}` :rainbow:'
+                    already_linked_team_name = fyle_user.slack_team.name
+                    current_team_name = slack_team.name
+                    fyle_user_email = fyle_user.email
+                    message = ':x: Unable to link your Fyle account! :confused: \n\n' \
+                                f'It looks like your Fyle account with `{fyle_user_email}` is already linked with _*{already_linked_team_name}*_ workspace. ' \
+                                'One Fyle account can be linked to only 1 workspace in Slack. :upside_down_face: \n\n' \
+                                f'If you wish to link your account with _*{current_team_name}*_ workspace, you would need to unlink your' \
+                                f'Fyle account from _*{already_linked_team_name}*_ workspace. :hammer_and_wrench: \n\n' \
+                                f'Once the account is unlinked from _*{already_linked_team_name}*_ workspace, you could try linking your account again in _*{current_team_name}*_ workspace. :rainbow:'
                     self.send_linked_account_message(slack_client, slack_user_dm_channel_id, message)
                 
                 else:

--- a/fyle_slack_app/fyle/authorization/views.py
+++ b/fyle_slack_app/fyle/authorization/views.py
@@ -1,4 +1,3 @@
-from logging import log
 from typing import Dict
 
 import uuid
@@ -76,7 +75,8 @@ class FyleAuthorization(View):
                 if fyle_user is not None:
                     # If the fyle user already exists, send a message to user indicating they've already 
                     # linked their Fyle account in one of their slack workspace
-                    self.send_linked_account_message(slack_client, slack_user_dm_channel_id)
+                    team_name = fyle_user.slack_team.name
+                    self.send_linked_account_message(slack_client, slack_user_dm_channel_id, team_name)
                 
                 else:
                     # Putting below logic inside a transaction block to prevent bad data
@@ -130,10 +130,15 @@ class FyleAuthorization(View):
         )
 
 
-    def send_linked_account_message(self, slack_client: WebClient, slack_user_dm_channel_id: str) -> None:
+    def send_linked_account_message(self, slack_client: WebClient, slack_user_dm_channel_id: str, workspace_name: str = None) -> None:
+        if workspace_name is not None:
+            message = f'Hey buddy you\'ve already linked your *Fyle* account in this workspace `{workspace_name}` :rainbow:'
+        else:
+            message = 'Hey buddy you\'ve already linked your *Fyle* account :rainbow:'
+        
         slack_client.chat_postMessage(
             channel=slack_user_dm_channel_id,
-            text='Hey buddy you\'ve already linked your *Fyle* account :rainbow:'
+            text=message
         )
 
 

--- a/fyle_slack_app/fyle/authorization/views.py
+++ b/fyle_slack_app/fyle/authorization/views.py
@@ -62,7 +62,7 @@ class FyleAuthorization(View):
             user = utils.get_or_none(User, slack_user_id=state_params['user_id'])
 
             if user is not None:
-                # If the user already exists send a message to user indicating they've already linked Fyle account
+                # If the user already exists, send a message to user indicating they've already linked Fyle account
                 self.send_linked_account_message(slack_client, slack_user_dm_channel_id)
 
             else:
@@ -74,6 +74,13 @@ class FyleAuthorization(View):
                     fyle_refresh_token = fyle_utils.get_fyle_refresh_token(code)
 
                     fyle_profile = fyle_utils.get_fyle_profile(fyle_refresh_token)
+
+                    fyle_user = utils.get_or_none(User, fyle_user_id=fyle_profile['user_id'])
+
+                    if fyle_user is not None:
+                        # If the fyle user already exists, send a message to user indicating they've already 
+                        # linked their Fyle account in one of their slack workspace
+                        self.send_linked_account_message(slack_client, slack_user_dm_channel_id)
 
                     # Create user
                     user = self.create_user(slack_client, slack_team, state_params['user_id'], slack_user_dm_channel_id, fyle_refresh_token, fyle_profile['user_id'])

--- a/fyle_slack_app/fyle/authorization/views.py
+++ b/fyle_slack_app/fyle/authorization/views.py
@@ -82,7 +82,7 @@ class FyleAuthorization(View):
                     message = ':x: Unable to link your Fyle account! :confused: \n\n' \
                                 f'It looks like your Fyle account with `{fyle_user_email}` is already linked with _*{already_linked_team_name}*_ workspace. ' \
                                 'One Fyle account can be linked to only 1 workspace in Slack. :upside_down_face: \n\n' \
-                                f'If you wish to link your account with _*{current_team_name}*_ workspace, you would need to unlink your' \
+                                f'If you wish to link your account with _*{current_team_name}*_ workspace, you would need to unlink your ' \
                                 f'Fyle account from _*{already_linked_team_name}*_ workspace. :hammer_and_wrench: \n\n' \
                                 f'Once the account is unlinked from _*{already_linked_team_name}*_ workspace, you could try linking your account again in _*{current_team_name}*_ workspace. :rainbow:'
                     self.send_linked_account_message(slack_client, slack_user_dm_channel_id, message)

--- a/fyle_slack_service/urls.py
+++ b/fyle_slack_service/urls.py
@@ -30,7 +30,7 @@ from fyle_slack_service import ready
 urlpatterns = [
     path('admin/', admin.site.urls),
 
-    #Kubernetes ready call
+    # Kubernetes ready call
     path('ready', ready),
 
     # Slack routes

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -129,9 +129,6 @@ def test_fyle_authorization(create_notification_subscription, track_fyle_authori
     mock_fyle_profile = mock_fyle.spender.my_profile.get()['data']
     fyle_utils.get_fyle_profile.return_value = mock_fyle_profile
 
-    mock_fyle_user = mock.Mock(spec=User)
-    utils.get_or_none.side_effect = [mock_fyle_user, None]
-
     mock_user = mock.Mock(spec=User)
     create_user.return_value = mock_user
     send_post_authorization_message.return_value = True

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -155,13 +155,14 @@ def test_fyle_authorization(create_notification_subscription, track_fyle_authori
     send_post_authorization_message.assert_called_with(slack_client(), mock_slack_user_dm_channel_id)
 
     # Check is get_or_none function has been called twice
-    assert utils.get_or_none.call_count == 2
+    assert utils.get_or_none.call_count == 3
 
-    # We call get_or_none twice in view to be tested
+    # We call get_or_none thrice in view to be tested
     # This check if the parameters passed in each call are correct or not
     expected_calls = [
         mock.call(Team, id=state_params['team_id']),
-        mock.call(User, slack_user_id=state_params['user_id'])
+        mock.call(User, slack_user_id=state_params['user_id']),
+        mock.call(User, fyle_user_id=mock_fyle_profile['user_id'])
     ]
 
     utils.get_or_none.assert_has_calls(expected_calls)

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -154,7 +154,7 @@ def test_fyle_authorization(create_notification_subscription, track_fyle_authori
     send_post_authorization_message.assert_called_once()
     send_post_authorization_message.assert_called_with(slack_client(), mock_slack_user_dm_channel_id)
 
-    # Check is get_or_none function has been called twice
+    # Check is get_or_none function has been called thrice
     assert utils.get_or_none.call_count == 3
 
     # We call get_or_none thrice in view to be tested

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -112,7 +112,7 @@ def test_fyle_authorization(create_notification_subscription, track_fyle_authori
     # Returns next value each time get_or_none is called
     # in function which is to be tested
     mock_team = mock.Mock(spec=Team)
-    utils.get_or_none.side_effect = [mock_team, None]
+    utils.get_or_none.side_effect = [mock_team, None, None]
 
     utils.decode_state = decode_state
 

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -129,6 +129,9 @@ def test_fyle_authorization(create_notification_subscription, track_fyle_authori
     mock_fyle_profile = mock_fyle.spender.my_profile.get()['data']
     fyle_utils.get_fyle_profile.return_value = mock_fyle_profile
 
+    mock_fyle_user = mock.Mock(spec=User)
+    utils.get_or_none.side_effect = [mock_fyle_user, None]
+
     mock_user = mock.Mock(spec=User)
     create_user.return_value = mock_user
     send_post_authorization_message.return_value = True


### PR DESCRIPTION
Changes -
- if user tries to link an already linked account in a different workspace, user will get a message like this -
![Screenshot 2021-12-28 at 2 17 30 PM](https://user-images.githubusercontent.com/41716010/147547895-bdcf41b0-ae46-4310-b529-8e92ca3dc7b1.png)


[Clickup](https://app.clickup.com/t/1wn3qx4)