### PR TITLE
Enable approvers to review report expenses from Slack itself

### DIFF
--- a/fyle_slack_app/fyle/report_approvals/tasks.py
+++ b/fyle_slack_app/fyle/report_approvals/tasks.py
@@ -11,7 +11,7 @@ from fyle_slack_app.libs import logger
 from fyle_slack_app.fyle import utils as fyle_utils
 from fyle_slack_app.libs import utils, assertions
 from fyle_slack_app.slack.ui.notifications import messages as notification_messages
-from fyle_slack_app.slack.ui import common_messages as common_messages
+from fyle_slack_app.slack.ui import common_messages
 
 
 logger = logger.get_logger(__name__)

--- a/fyle_slack_app/fyle/report_approvals/tasks.py
+++ b/fyle_slack_app/fyle/report_approvals/tasks.py
@@ -11,6 +11,7 @@ from fyle_slack_app.libs import logger
 from fyle_slack_app.fyle import utils as fyle_utils
 from fyle_slack_app.libs import utils, assertions
 from fyle_slack_app.slack.ui.notifications import messages as notification_messages
+from fyle_slack_app.slack.ui import common_messages as common_messages
 
 
 logger = logger.get_logger(__name__)
@@ -38,6 +39,7 @@ def process_report_approval(report_id: str, user_id: str, team_id: str, message_
 
     # Check if report is deleted
     if report is None:
+        no_report_access_message = 'Looks like you no longer have access to this expense report :face_with_head_bandage:'
         report_notification_message = common_messages.get_updated_approval_notification_message(notification_message=notification_message, custom_message=no_report_access_message, cta=False)
     else:
         report = report['data']

--- a/fyle_slack_app/fyle/report_approvals/views.py
+++ b/fyle_slack_app/fyle/report_approvals/views.py
@@ -26,6 +26,11 @@ class FyleReportApproval:
         return approver_report
 
 
+    def get_approver_report_expenses(self, query_params: dict) -> Dict:
+        approver_report_expenses = self.connection.v1beta.approver.expenses.list(query_params=query_params)
+        return approver_report_expenses
+
+
     def approve_report(self, report_id: str) -> Dict:
         approved_report = self.connection.v1beta.approver.reports.approve(report_id)
         return approved_report
@@ -67,9 +72,14 @@ class FyleReportApproval:
 
 
     @staticmethod
-    def track_report_approved(user: User, report: Dict) -> None:
+    def track_report_approved(user: User, report: Dict, modal: bool = False) -> None:
         event_data = FyleNotificationView.get_report_tracking_data(user, report)
 
         tracking.identify_user(user.email)
 
-        tracking.track_event(user.email, 'Report Approved From Slack', event_data)
+        if modal is True:
+            event_name = 'Report Approved From Slack Modal'
+        else:
+            event_name = 'Report Approved From Slack'
+
+        tracking.track_event(user.email, event_name, event_data)

--- a/fyle_slack_app/models/user_feedbacks.py
+++ b/fyle_slack_app/models/user_feedbacks.py
@@ -69,7 +69,7 @@ class UserFeedback(models.Model):
             )
             user_email = user.email
             event_data = {
-                'feedback_trigger': feedback_trigger,
+                'feedback_trigger': feedback_trigger.value,
                 'email': user_email,
                 'slack_user_id': user.slack_user_id
             }

--- a/fyle_slack_app/slack/interactives/block_action_handlers.py
+++ b/fyle_slack_app/slack/interactives/block_action_handlers.py
@@ -9,8 +9,7 @@ from fyle_slack_app.libs import assertions, utils, logger
 
 from fyle_slack_app.slack.ui.feedbacks import messages as feedback_messages
 from fyle_slack_app.slack.ui.modals import messages as modal_messages
-from fyle_slack_app.slack.ui import common_messages as common_messages
-from fyle_slack_app.slack.interactives import tasks as tasks
+from fyle_slack_app.slack.ui import common_messages
 from fyle_slack_app.slack import utils as slack_utils
 from fyle_slack_app import tracking
 

--- a/fyle_slack_app/slack/interactives/block_action_handlers.py
+++ b/fyle_slack_app/slack/interactives/block_action_handlers.py
@@ -1,15 +1,11 @@
-from typing import Callable, Dict, List
+from typing import Callable, Dict
 
 from django.http import JsonResponse
 from django_q.tasks import async_task
 
-from fyle.platform import exceptions
-
 from fyle_slack_app.models import User, NotificationPreference, UserFeedback
 from fyle_slack_app.models.notification_preferences import NotificationType
 from fyle_slack_app.libs import assertions, utils, logger
-
-from fyle_slack_app.fyle.report_approvals.views import FyleReportApproval
 
 from fyle_slack_app.slack.ui.feedbacks import messages as feedback_messages
 from fyle_slack_app.slack.ui.modals import messages as modal_messages
@@ -17,7 +13,6 @@ from fyle_slack_app.slack.ui import common_messages as common_messages
 from fyle_slack_app.slack.interactives import tasks as tasks
 from fyle_slack_app.slack import utils as slack_utils
 from fyle_slack_app import tracking
-from fyle_slack_app.slack.ui.common_messages import IN_PROGRESS_MESSAGE
 
 
 logger = logger.get_logger(__name__)
@@ -115,7 +110,7 @@ class BlockActionHandler:
         is_approved_from_modal = slack_payload['is_approved_from_modal'] if 'is_approved_from_modal' in slack_payload else False
 
         # Overriding the 'approve' cta text to 'approving'
-        in_progress_message_block = IN_PROGRESS_MESSAGE[slack_utils.AsyncOperation.APPROVING_REPORT.value]
+        in_progress_message_block = common_messages.IN_PROGRESS_MESSAGE[slack_utils.AsyncOperation.APPROVING_REPORT.value]
         message_blocks[3]['elements'][0] = in_progress_message_block
 
         slack_client = slack_utils.get_slack_client(team_id)

--- a/fyle_slack_app/slack/interactives/block_action_handlers.py
+++ b/fyle_slack_app/slack/interactives/block_action_handlers.py
@@ -38,7 +38,7 @@ class BlockActionHandler:
             'report_commented_notification_preference': self.handle_notification_preference_selection,
             'expense_commented_notification_preference': self.handle_notification_preference_selection,
             'open_feedback_dialog': self.handle_feedback_dialog,
-            'open_report_expense_dialog': self.handle_report_expense_dialog
+            'open_report_expenses_dialog': self.handle_report_expenses_dialog
         }
 
 

--- a/fyle_slack_app/slack/interactives/block_action_handlers.py
+++ b/fyle_slack_app/slack/interactives/block_action_handlers.py
@@ -199,7 +199,7 @@ class BlockActionHandler:
 
 
     def handle_report_expense_dialog(self, slack_payload: Dict, user_id: str, team_id: str) -> None:
-        pass
+        return JsonResponse({}, status=200)
 
 
     def track_view_in_fyle_action(self, user_id: str, event_name: str, event_data: Dict) -> None:

--- a/fyle_slack_app/slack/interactives/block_action_handlers.py
+++ b/fyle_slack_app/slack/interactives/block_action_handlers.py
@@ -37,7 +37,8 @@ class BlockActionHandler:
             'report_paid_notification_preference': self.handle_notification_preference_selection,
             'report_commented_notification_preference': self.handle_notification_preference_selection,
             'expense_commented_notification_preference': self.handle_notification_preference_selection,
-            'open_feedback_dialog': self.handle_feedback_dialog
+            'open_feedback_dialog': self.handle_feedback_dialog,
+            'open_report_expense_dialog': self.handle_report_expense_dialog
         }
 
 

--- a/fyle_slack_app/slack/interactives/tasks.py
+++ b/fyle_slack_app/slack/interactives/tasks.py
@@ -37,6 +37,8 @@ def handle_feedback_submission(user: User, team_id: str, form_values: Dict, priv
     user_email = user.email
     event_data = {
         'feedback_trigger': feedback_trigger,
+        'comment': comment,
+        'rating': rating,
         'email': user_email,
         'slack_user_id': user.slack_user_id
     }

--- a/fyle_slack_app/slack/interactives/tasks.py
+++ b/fyle_slack_app/slack/interactives/tasks.py
@@ -1,14 +1,17 @@
 from typing import Dict
 
+from fyle.platform import exceptions
+
 from fyle_slack_app.fyle.report_approvals.views import FyleReportApproval
 
 from fyle_slack_app.models import User, UserFeedbackResponse
 from fyle_slack_app.slack import utils as slack_utils
 from fyle_slack_app.slack.ui.feedbacks import messages as feedback_messages
 from fyle_slack_app.slack.ui.modals import messages as modal_messages
+from fyle_slack_app.slack.ui import common_messages as common_messages
 from fyle_slack_app import tracking
 
-from fyle_slack_app.libs import utils, assertions, logger
+from fyle_slack_app.libs import utils, logger
 
 logger = logger.get_logger(__name__)
 

--- a/fyle_slack_app/slack/interactives/tasks.py
+++ b/fyle_slack_app/slack/interactives/tasks.py
@@ -1,9 +1,16 @@
 from typing import Dict
 
+from fyle_slack_app.fyle.report_approvals.views import FyleReportApproval
+
 from fyle_slack_app.models import User, UserFeedbackResponse
 from fyle_slack_app.slack import utils as slack_utils
 from fyle_slack_app.slack.ui.feedbacks import messages as feedback_messages
+from fyle_slack_app.slack.ui.modals import messages as modal_messages
 from fyle_slack_app import tracking
+
+from fyle_slack_app.libs import utils, assertions, logger
+
+logger = logger.get_logger(__name__)
 
 
 def handle_feedback_submission(user: User, team_id: str, form_values: Dict, private_metadata: Dict):
@@ -45,3 +52,71 @@ def handle_feedback_submission(user: User, team_id: str, form_values: Dict, priv
 
     tracking.identify_user(user_email)
     tracking.track_event(user_email, 'Feedback Submitted', event_data)
+
+
+def handle_fetching_of_report_and_its_expenses(user: User, team_id: str, private_metadata: Dict, modal_view_id: str):
+    slack_client = slack_utils.get_slack_client(team_id)
+
+    # Fetch the report
+    fyle_report_approval = FyleReportApproval(user)
+
+    try:
+        report = fyle_report_approval.get_report_by_id(private_metadata['report_id'])
+        report = report['data']
+    except exceptions.NotFoundItemError as error:
+        logger.error('Report not found with id -> %s', private_metadata['report_id'])
+        logger.error('Error -> %s', error)
+        # None here means report is deleted/doesn't exist
+        report = None
+
+    if report is None:
+        # Show no report-access message
+        no_report_access_message = 'Looks like you no longer have access to this expense report :face_with_head_bandage:'
+        report_notification_message = common_messages.get_updated_approval_notification_message(notification_message=private_metadata['notification_message_blocks'], custom_message=no_report_access_message, cta=False)
+        modal_message = modal_messages.get_report_expenses_dialog(custom_message=no_report_access_message)
+
+        # Update message in modal
+        slack_client.views_update(user=user.slack_user_id, view=modal_message, view_id=modal_view_id)
+
+        # Update notification message
+        slack_client.chat_update(
+            channel=user.slack_dm_channel_id,
+            blocks=report_notification_message,
+            ts=private_metadata['notification_message_ts']
+        )
+
+    else:
+        encoded_private_metadata = utils.encode_state(private_metadata)
+        fetch_report_expenses(user=user, team_id=team_id, report=report, modal_view_id=modal_view_id, private_metadata=encoded_private_metadata)
+        event_data = {
+            'email': user.email,
+            'slack_user_id': user.slack_user_id
+        }
+
+        tracking.identify_user(user.email)
+        tracking.track_event(user.email, 'Report Expense Modal Opened', event_data)
+
+
+
+def fetch_report_expenses(user: User, team_id: str, report: Dict, modal_view_id: str, private_metadata: str):
+    slack_client = slack_utils.get_slack_client(team_id)
+
+    fyle_report_approval = FyleReportApproval(user)
+    query_params = {
+        'report_id': 'eq.{}'.format(report['id']),
+        'order': 'created_at.desc',
+        'limit': '15',
+        'offset': '0'
+    }
+
+    try:
+        approver_report_expenses = fyle_report_approval.get_approver_report_expenses(query_params=query_params)
+        report_expenses = approver_report_expenses['data']
+    except exceptions.NotFoundItemError as error:
+        logger.error('Report expenses not found with id -> %s', report['id'])
+        logger.error('Error -> %s', error)
+        # None here means report is deleted/doesn't exist
+        report_expenses = None
+
+    report_expenses_dialog = modal_messages.get_report_expenses_dialog(user=user, report=report, report_expenses=report_expenses, private_metadata=private_metadata)
+    slack_client.views_update(user=user.slack_user_id, view=report_expenses_dialog, view_id=modal_view_id)

--- a/fyle_slack_app/slack/interactives/tasks.py
+++ b/fyle_slack_app/slack/interactives/tasks.py
@@ -8,7 +8,7 @@ from fyle_slack_app.models import User, UserFeedbackResponse
 from fyle_slack_app.slack import utils as slack_utils
 from fyle_slack_app.slack.ui.feedbacks import messages as feedback_messages
 from fyle_slack_app.slack.ui.modals import messages as modal_messages
-from fyle_slack_app.slack.ui import common_messages as common_messages
+from fyle_slack_app.slack.ui import common_messages
 from fyle_slack_app import tracking
 
 from fyle_slack_app.libs import utils, logger

--- a/fyle_slack_app/slack/interactives/view_submission_handlers.py
+++ b/fyle_slack_app/slack/interactives/view_submission_handlers.py
@@ -89,4 +89,4 @@ class ViewSubmissionHandler:
 
         BlockActionHandler().approve_report(slack_payload=slack_payload, user_id=user_id, team_id=team_id)
 
-        return JsonResponse({})
+        return JsonResponse({}, status=200)

--- a/fyle_slack_app/slack/interactives/view_submission_handlers.py
+++ b/fyle_slack_app/slack/interactives/view_submission_handlers.py
@@ -4,7 +4,6 @@ from django.http.response import JsonResponse
 
 from django_q.tasks import async_task
 
-from fyle_slack_app import tracking
 from fyle_slack_app.models.users import User
 from fyle_slack_app.slack import utils as slack_utils
 from fyle_slack_app.slack.interactives.block_action_handlers import BlockActionHandler
@@ -73,8 +72,6 @@ class ViewSubmissionHandler:
 
 
     def handle_report_approval_from_modal(self, slack_payload: Dict, user_id: str, team_id: str) -> JsonResponse:
-        user = utils.get_or_none(User, slack_user_id=user_id)
-
         encoded_private_metadata = slack_payload['view']['private_metadata']
         private_metadata = utils.decode_state(encoded_private_metadata)
 

--- a/fyle_slack_app/slack/interactives/view_submission_handlers.py
+++ b/fyle_slack_app/slack/interactives/view_submission_handlers.py
@@ -4,8 +4,10 @@ from django.http.response import JsonResponse
 
 from django_q.tasks import async_task
 
+from fyle_slack_app import tracking
 from fyle_slack_app.models.users import User
 from fyle_slack_app.slack import utils as slack_utils
+from fyle_slack_app.slack.interactives.block_action_handlers import BlockActionHandler
 from fyle_slack_app.libs import utils
 
 
@@ -16,7 +18,8 @@ class ViewSubmissionHandler:
     # Maps action_id with it's respective function
     def _initialize_view_submission_handlers(self):
         self._view_submission_handlers = {
-            'feedback_submission': self.handle_feedback_submission
+            'feedback_submission': self.handle_feedback_submission,
+            'report_approval_from_modal': self.handle_report_approval_from_modal
         }
 
 
@@ -65,5 +68,28 @@ class ViewSubmissionHandler:
             form_values,
             private_metadata
         )
+
+        return JsonResponse({})
+
+
+    def handle_report_approval_from_modal(self, slack_payload: Dict, user_id: str, team_id: str) -> JsonResponse:
+        user = utils.get_or_none(User, slack_user_id=user_id)
+
+        encoded_private_metadata = slack_payload['view']['private_metadata']
+        private_metadata = utils.decode_state(encoded_private_metadata)
+
+        # Modifying the slack payload in order to mimic the payload structure sent to "approve_report" function
+        slack_payload['actions'] = [
+            {
+                'value': private_metadata['report_id']
+            }
+        ]
+
+        slack_payload['message'] = {}
+        slack_payload['message']['ts'] = private_metadata['notification_message_ts']
+        slack_payload['message']['blocks'] = private_metadata['notification_message_blocks']
+        slack_payload['is_approved_from_modal'] = True
+
+        BlockActionHandler().approve_report(slack_payload=slack_payload, user_id=user_id, team_id=team_id)
 
         return JsonResponse({})

--- a/fyle_slack_app/slack/ui/authorization/messages.py
+++ b/fyle_slack_app/slack/ui/authorization/messages.py
@@ -113,7 +113,17 @@ def get_post_authorization_message() -> List[Dict]:
                     "style": "primary",
                     "text": {
                         "type": "plain_text",
-                        "text": "Approve",
+                        "text": ":rocket: Approve",
+                    },
+                    "value": "pre_auth_message_approve",
+                    "action_id": "pre_auth_message_approve"
+                },
+                {
+                    "type": "button",
+                    "style": "primary",
+                    "text": {
+                        "type": "plain_text",
+                        "text": ":slack: Review in Slack",
                     },
                     "value": "pre_auth_message_approve",
                     "action_id": "pre_auth_message_approve"
@@ -122,7 +132,7 @@ def get_post_authorization_message() -> List[Dict]:
                     "type": "button",
                     "text": {
                         "type": "plain_text",
-                        "text": "Review in Fyle",
+                        "text": ":eyes: Review in Fyle",
                     },
                     "value": "pre_auth_message_view_in_fyle",
                     "action_id": "pre_auth_message_view_in_fyle"

--- a/fyle_slack_app/slack/ui/common_messages.py
+++ b/fyle_slack_app/slack/ui/common_messages.py
@@ -1,3 +1,4 @@
+from typing import Dict, List
 from fyle_slack_app.slack import utils as slack_utils
 
 IN_PROGRESS_MESSAGE = {
@@ -13,10 +14,30 @@ IN_PROGRESS_MESSAGE = {
         'style': 'primary',
         'text': {
             'type': 'plain_text',
-            'text': 'Approving :hourglass_flowing_sand:',
+            'text': ':hourglass_flowing_sand: Approving',
             'emoji': True
         },
         'action_id': 'pre_auth_message_approve',
         'value': 'pre_auth_message_approve',
     }
 }
+
+
+def get_updated_approval_notification_message(notification_message: List[Dict], custom_message: str, cta: bool) -> List[Dict]:
+    report_notification_message = []
+    for message_block in notification_message:
+        if cta is False and message_block['type'] == 'actions':
+            continue
+        report_notification_message.append(message_block)
+
+    # report_message = 'Looks like you no longer have access to this expense report :face_with_head_bandage:'
+    report_section = {
+        'type': 'section',
+        'text': {
+            'type': 'mrkdwn',
+            'text': custom_message
+        }
+    }
+    report_notification_message.insert(3, report_section)
+
+    return report_notification_message

--- a/fyle_slack_app/slack/ui/common_messages.py
+++ b/fyle_slack_app/slack/ui/common_messages.py
@@ -30,7 +30,6 @@ def get_updated_approval_notification_message(notification_message: List[Dict], 
             continue
         report_notification_message.append(message_block)
 
-    # report_message = 'Looks like you no longer have access to this expense report :face_with_head_bandage:'
     report_section = {
         'type': 'section',
         'text': {

--- a/fyle_slack_app/slack/ui/modals/messages.py
+++ b/fyle_slack_app/slack/ui/modals/messages.py
@@ -1,0 +1,224 @@
+from typing import Dict, List
+
+from fyle_slack_app.models import User
+from fyle_slack_app.libs import utils
+
+from fyle_slack_app.fyle import utils as fyle_utils
+from fyle_slack_app.slack import utils as slack_utils
+
+
+def get_report_expenses_dialog(user: User = None, report: Dict = None, private_metadata: str = None, report_expenses: List[Dict] = None, custom_message: str = None) -> Dict:
+
+    '''
+    NOTE: Before increasing the block elements of this modal, please make sure that the total count does not exceed 100, 
+    since slack has set a limit of 100.
+    '''
+
+    # Show custom modal message
+    if custom_message is not None and report is None and report_expenses is None:
+        report_expenses_dialog = {
+            'type': 'modal',
+            'callback_id': 'report_approval_from_modal',
+            'title': {
+                'type': 'plain_text',
+                'text': 'Report Details',
+            },
+            'blocks': [
+                {
+                    'type': 'section',
+                    'text': {
+                        'type': 'mrkdwn',
+                        'text': custom_message
+                    }
+                }
+            ]
+        }
+    
+    else:
+    
+        report_url = fyle_utils.get_fyle_resource_url(user.fyle_refresh_token, report, 'REPORT')
+
+        report_expenses_dialog = get_report_section(report=report, report_url=report_url, private_metadata=private_metadata)
+
+        # Append report expenses section to the modal message
+        expenses_section_blocks = get_report_expenses_section(user=user, report_expenses=report_expenses)
+        report_expenses_dialog['blocks'].extend(expenses_section_blocks)
+
+        # Show a hyperlink to redirect the user to fyle web-app, if a report has more than 15 expenses
+        if report['num_expenses'] > 15:
+            view_more_expenses_message = get_view_more_expenses_section(report_url)
+            report_expenses_dialog['blocks'].extend(view_more_expenses_message)
+
+    return report_expenses_dialog
+
+
+def get_report_section(report: Dict, report_url: str, private_metadata: str) -> List[Dict]:
+    report_currency_symbol = slack_utils.get_currency_symbol(report['currency'])
+
+    report_expenses_dialog = {
+        'type': 'modal',
+        'callback_id': 'report_approval_from_modal',
+        'private_metadata': private_metadata,
+        'title': {
+            'type': 'plain_text',
+            'text': 'Report Details',
+        },
+        'submit': {
+            'type': 'plain_text',
+            'text': ':rocket: Approve'
+        },
+        'close': {
+            'type': 'plain_text',
+            'text': 'Close',
+            'emoji': True
+        },
+        'blocks': [
+            {
+                'type': 'divider'
+            },
+            {
+                'type': 'section',
+                'fields': [
+                    {
+                        'type': 'mrkdwn',
+                        'text': 'Report Name:\n *<{}|{}>*'.format(report_url, report['purpose'])
+                    },
+                    {
+                        'type': 'mrkdwn',
+                        'text': 'Spender:\n *{}*'.format(report['user']['email'])
+                    }
+                ]
+            },
+            {
+                'type': 'section',
+                'text': {
+                    'type': 'mrkdwn',
+                    'text': '\n'
+                }
+            },
+            {
+                'type': 'section',
+                'text': {
+                    'type': 'mrkdwn',
+                    'text': '\n'
+                }
+            },
+            {
+                'type': 'section',
+                'text': {
+                    'type': 'mrkdwn',
+                    'text': ':page_facing_up: *Expenses ({}) for {} {}*'.format(report['num_expenses'], report_currency_symbol, report['amount'])
+                }
+            }
+        ]
+    }
+    
+    return report_expenses_dialog
+
+
+def get_report_expenses_section(user: User, report_expenses: List[Dict]) -> List[Dict]:
+    expense_section_blocks = []
+
+    # Iterate and append all report expenses to report_expenses_dialog message
+    for expense in report_expenses:
+
+        expense_block = [
+            {
+                'type': 'divider'
+            }
+        ]
+        
+        # Compose and append expense title message
+        if expense['category'] and expense['category']['name'] and expense['category']['name'] != 'Unspecified':
+            if expense['merchant']:
+                expense_initial_text = '*{} ({})*'.format(expense['category']['name'], expense['merchant'])
+            else:
+                expense_initial_text = '*{}*'.format(expense['category']['name'])
+        else:
+            expense_initial_text = 'An'
+        
+        expense_url = fyle_utils.get_fyle_resource_url(user.fyle_refresh_token, expense, 'EXPENSE')
+        expense_currency_symbol = slack_utils.get_currency_symbol(expense['currency'])
+        expense_block_title = {
+            'type': 'section',
+            'text': {
+                'type': 'mrkdwn',
+                'text': '{} expense of :dollar: *<{}|{} {}>*'.format(expense_initial_text, expense_url, expense_currency_symbol, expense['amount'])
+            }
+        }
+        expense_block.append(expense_block_title)
+
+        # Compose and append expense block fields
+        readable_spend_date = utils.get_formatted_datetime(expense['spent_at'], '%B %d, %Y')
+        expense_block_fields = {
+            'type': 'section',
+            'fields': [
+                {
+                    'type': 'mrkdwn',
+                    'text': 'Date of Spend:\n *{}*'.format(readable_spend_date)
+                }
+            ]
+        }
+
+        is_receipt_attached_message = ':white_check_mark: *Attached*' if len(expense['file_ids']) > 0 else ':x: *Missing*'
+        expense_block_fields['fields'].append({
+            'type': 'mrkdwn',
+            'text': 'Receipt:\n {}'.format(is_receipt_attached_message)
+        })
+
+        expense_block.append(expense_block_fields)
+
+        # Show expense-purpose field only if is present
+        if expense['purpose']:
+            expense_block.append({
+                'type': 'section',
+                'fields': [
+                    {
+                        'type': 'mrkdwn',
+                        'text': 'Purpose:\n *{}*'.format(expense['purpose'])
+                    }
+                ]
+            })
+        
+        # Add extra section space after each expense
+        expense_block.append({
+            'type': 'section',
+            'fields': [
+                {
+                    'type': 'mrkdwn',
+                    'text': ' '
+                }
+            ]
+        })
+
+        expense_section_blocks.extend(expense_block)
+    
+    return expense_section_blocks
+
+
+def get_view_more_expenses_section(report_url: str) -> List[Dict]:
+    view_more_expenses_message = [
+        {
+            'type': 'divider'
+        },
+        {
+            'type': 'section',
+            'fields': [
+                {
+                    'type': 'mrkdwn',
+                    'text': ' '
+                }
+            ]
+        },
+        {
+            'type': 'context',
+            'elements': [
+                {
+                    'type': 'mrkdwn',
+                    'text': '<{}|*View rest of the expenses in Fyle*> :arrow_upper_right:'.format(report_url)
+                }
+            ]
+        }
+    ]
+
+    return view_more_expenses_message

--- a/fyle_slack_app/slack/ui/modals/messages.py
+++ b/fyle_slack_app/slack/ui/modals/messages.py
@@ -10,7 +10,7 @@ from fyle_slack_app.slack import utils as slack_utils
 def get_report_expenses_dialog(user: User = None, report: Dict = None, private_metadata: str = None, report_expenses: List[Dict] = None, custom_message: str = None) -> Dict:
 
     '''
-    NOTE: Before increasing the block elements of this modal, please make sure that the total count does not exceed 100, 
+    NOTE: Before increasing the block elements of this modal, please make sure that the total count does not exceed 100,
     since slack has set a limit of 100.
     '''
 

--- a/fyle_slack_app/slack/ui/modals/messages.py
+++ b/fyle_slack_app/slack/ui/modals/messages.py
@@ -33,9 +33,9 @@ def get_report_expenses_dialog(user: User = None, report: Dict = None, private_m
                 }
             ]
         }
-    
+
     else:
-    
+
         report_url = fyle_utils.get_fyle_resource_url(user.fyle_refresh_token, report, 'REPORT')
 
         report_expenses_dialog = get_report_section(report=report, report_url=report_url, private_metadata=private_metadata)
@@ -112,7 +112,7 @@ def get_report_section(report: Dict, report_url: str, private_metadata: str) -> 
             }
         ]
     }
-    
+
     return report_expenses_dialog
 
 
@@ -127,7 +127,7 @@ def get_report_expenses_section(user: User, report_expenses: List[Dict]) -> List
                 'type': 'divider'
             }
         ]
-        
+
         # Compose and append expense title message
         if expense['category'] and expense['category']['name'] and expense['category']['name'] != 'Unspecified':
             if expense['merchant']:
@@ -136,7 +136,7 @@ def get_report_expenses_section(user: User, report_expenses: List[Dict]) -> List
                 expense_initial_text = '*{}*'.format(expense['category']['name'])
         else:
             expense_initial_text = 'An'
-        
+
         expense_url = fyle_utils.get_fyle_resource_url(user.fyle_refresh_token, expense, 'EXPENSE')
         expense_currency_symbol = slack_utils.get_currency_symbol(expense['currency'])
         expense_block_title = {
@@ -179,7 +179,7 @@ def get_report_expenses_section(user: User, report_expenses: List[Dict]) -> List
                     }
                 ]
             })
-        
+
         # Add extra section space after each expense
         expense_block.append({
             'type': 'section',
@@ -192,7 +192,7 @@ def get_report_expenses_section(user: User, report_expenses: List[Dict]) -> List
         })
 
         expense_section_blocks.extend(expense_block)
-    
+
     return expense_section_blocks
 
 

--- a/fyle_slack_app/slack/ui/notifications/messages.py
+++ b/fyle_slack_app/slack/ui/notifications/messages.py
@@ -1,11 +1,14 @@
 from typing import Dict, List
+import json
 
 from fyle_slack_app.libs import utils
+from fyle_slack_app.slack import utils as slack_utils
 
 
 def get_report_section_blocks(title_text: str, report: Dict) -> List[Dict]:
 
     readable_submitted_at = utils.get_formatted_datetime(report['last_submitted_at'], '%B %d, %Y')
+    report_currency_symbol = slack_utils.get_currency_symbol(report['currency'])
 
     report_section_block = [
         {
@@ -34,7 +37,7 @@ def get_report_section_blocks(title_text: str, report: Dict) -> List[Dict]:
                 {
                     'type': 'mrkdwn',
                     'text': '*Amount:*\n {} {}'.format(
-                        report['currency'],
+                        report_currency_symbol,
                         report['amount']
                     )
                 },
@@ -57,17 +60,17 @@ def get_expense_section_blocks(title_text: str, expense: Dict) -> List[Dict]:
     if sub_category is not None and category != sub_category:
         category = '{} / {}'.format(category, sub_category)
 
-    currency = expense['currency']
+    currency_symbol = slack_utils.get_currency_sysmbol(expense['currency'])
     amount = expense['amount']
 
-    amount_details = '*Amount:*\n {} {}'.format(currency, amount)
+    amount_details = '*Amount:*\n {} {}'.format(currency_symbol, amount)
 
     # If foreign currency exists, then show foreign amount and currency
     if expense['foreign_currency'] is not None:
-        foreign_currency = expense['foreign_currency']
+        foreign_currency_symbol = slack_utils.get_currency_sysmbol(expense['foreign_currency'])
         foreign_amount = expense['foreign_amount']
 
-        amount_details = '{} \n ({} {})'.format(amount_details, foreign_currency, foreign_amount)
+        amount_details = '{} \n ({} {})'.format(amount_details, foreign_currency_symbol, foreign_amount)
 
     expense_section_block = [
         {
@@ -133,7 +136,7 @@ def get_expense_section_blocks(title_text: str, expense: Dict) -> List[Dict]:
     return expense_section_block
 
 
-def get_report_review_in_slack_action(report_url: str, button_text: str, report_id: str) -> Dict:
+def get_report_review_in_slack_action(button_text: str, report_id: str) -> Dict:
     report_review_in_slack_action = {
         'type': 'button',
         'style': 'primary',
@@ -142,9 +145,8 @@ def get_report_review_in_slack_action(report_url: str, button_text: str, report_
             'text': ':slack: {}'.format(button_text),
             'emoji': True
         },
-        'action_id': 'review_report_in_slack',
-        'url': report_url,
         'value': report_id,
+        'action_id': 'open_report_expenses_dialog'
     }
 
     return report_review_in_slack_action
@@ -394,7 +396,6 @@ def get_report_approval_notification(report: Dict, user_display_name: str, repor
         }
         report_section_block.append(message_section)
     else:
-        report_view_in_slack_action_text = 'Review in Slack'
         report_view_in_fyle_action_text = 'Review in Fyle'
 
         report_approve_action = {
@@ -410,8 +411,10 @@ def get_report_approval_notification(report: Dict, user_display_name: str, repor
         }
         actions_block['elements'].append(report_approve_action)
 
-    report_view_in_slack_section = get_report_review_in_slack_action(report_url, report_view_in_slack_action_text, report['id'])
-    actions_block['elements'].append(report_view_in_slack_section)
+        # Adding "Review in Slack" button to the message block
+        report_view_in_slack_action_text = 'Review in Slack'
+        report_view_in_slack_section = get_report_review_in_slack_action(report_view_in_slack_action_text, report['id'])
+        actions_block['elements'].append(report_view_in_slack_section)
 
     report_view_in_fyle_section = get_report_review_in_fyle_action(report_url, report_view_in_fyle_action_text, report['id'])
     actions_block['elements'].append(report_view_in_fyle_section)

--- a/fyle_slack_app/slack/ui/notifications/messages.py
+++ b/fyle_slack_app/slack/ui/notifications/messages.py
@@ -1,5 +1,4 @@
 from typing import Dict, List
-import json
 
 from fyle_slack_app.libs import utils
 from fyle_slack_app.slack import utils as slack_utils

--- a/fyle_slack_app/slack/utils.py
+++ b/fyle_slack_app/slack/utils.py
@@ -43,8 +43,9 @@ def get_currency_symbol(currency: str) -> str:
 
     try:
         curr = c.get_symbol(currency)
-    except error as e:
+    except ValueError as error:
         logger.error('Error fetching currency symbol of currency = %s', currency)
+        logger.error('Error -> %s', error)
         curr = currency
 
     return curr

--- a/fyle_slack_app/slack/utils.py
+++ b/fyle_slack_app/slack/utils.py
@@ -1,11 +1,14 @@
 from typing import Dict
 import enum
+from forex_python.converter import CurrencyCodes
 
 from slack_sdk.errors import SlackApiError
 from slack_sdk.web import WebClient
 
-from fyle_slack_app.libs import assertions, utils
+from fyle_slack_app.libs import assertions, utils, logger
 from fyle_slack_app.models import Team
+
+logger = logger.get_logger(__name__)
 
 
 class AsyncOperation(enum.Enum):
@@ -33,3 +36,15 @@ def get_user_display_name(slack_client: WebClient, user_details: Dict) -> str:
         user_display_name = user_details['full_name']
 
     return user_display_name
+
+
+def get_currency_symbol(currency: str) -> str:
+    c = CurrencyCodes()
+    
+    try:
+        curr = c.get_symbol(currency)
+    except:
+        logger.error('Error fetching currency symbol of currency = {}'.format(currency))
+        curr = currency
+    
+    return curr

--- a/fyle_slack_app/slack/utils.py
+++ b/fyle_slack_app/slack/utils.py
@@ -40,11 +40,11 @@ def get_user_display_name(slack_client: WebClient, user_details: Dict) -> str:
 
 def get_currency_symbol(currency: str) -> str:
     c = CurrencyCodes()
-    
+
     try:
         curr = c.get_symbol(currency)
-    except:
-        logger.error('Error fetching currency symbol of currency = {}'.format(currency))
+    except error as e:
+        logger.error('Error fetching currency symbol of currency = %s', currency)
         curr = currency
-    
+
     return curr

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ Django==3.1.14
 django-picklefield==3.0.1
 django-q==1.3.4
 future==0.18.2
-fyle==0.19.0
+fyle==0.22.0
 gunicorn==20.0.4
 idna==2.10
 iniconfig==1.1.1
@@ -43,3 +43,4 @@ urllib3==1.26.5
 wcwidth==0.2.5
 wrapt==1.12.1
 yarl==1.6.3
+forex-python==1.8

--- a/tests/test_report_approval.py
+++ b/tests/test_report_approval.py
@@ -53,9 +53,10 @@ def test_report_approve(user_feedback, notification_messages, fyle_utils, slack_
     mock_team_id = 'mock-team-id'
     mock_message_timestamp = 'mock-message-timestamp'
     mock_notification_message = 'mock-notification-message'
+    mock_is_approved_from_modal = 'mock-is-approved-from-modal'
     report_approved_message = 'Expense report approved :rocket:'
 
-    process_report_approval(mock_report_id, mock_fyle_user_id, mock_team_id, mock_message_timestamp, mock_notification_message)
+    process_report_approval(mock_report_id, mock_fyle_user_id, mock_team_id, mock_message_timestamp, mock_notification_message, mock_is_approved_from_modal)
 
     # Assertion check for required methods that have been called
 


### PR DESCRIPTION
### Context
As part of this 1st phase of this initiative, made few modifications in the report approval notifications message for approvers

Initiative - https://www.notion.so/fyleuniverse/Add-detailed-Report-View-for-report-approval-notifications-d5384286edf643d98b0cb408fc6962dd

ClickUp - https://app.clickup.com/t/1xbz27r

---
### Screenshots
![Screenshot 2022-03-01 at 8 29 46 PM](https://user-images.githubusercontent.com/41716010/156193470-4d51ca41-03a2-4739-9211-21f361ca7f93.png)

---
**Note** - Modal related changes will be raised separately in another PR

