### PR TITLE
Add trackers for expense creation from slack

### DIFF
--- a/fyle_slack_app/slack/commands/tasks.py
+++ b/fyle_slack_app/slack/commands/tasks.py
@@ -112,4 +112,6 @@ def open_expense_form(user: User, team_id: str, view_id: str) -> None:
         **expense_form_details
     )
 
+    FyleExpense(user).track_expense_creation(user, 'User opened Expense Form modal using Slack slash command')
+
     slack_client.views_update(view=expense_form, view_id=view_id)

--- a/fyle_slack_app/slack/events/tasks.py
+++ b/fyle_slack_app/slack/events/tasks.py
@@ -162,6 +162,9 @@ def handle_file_shared(file_id: str, user_id: str, team_id: str):
         except assertions.InvalidUsage:
             error_message = 'Seems like something went wrong while creating an expense, please try again or contact support@fylehq.com'
             slack_client.chat_postMessage(channel=user.slack_dm_channel_id, text=error_message, thread_ts=message_ts, reply_broadcast=True)
+
+        FyleExpense(user).track_expense_creation(user, 'Expense created from uploading Receipt in Slack', expense['data'][0]['id'])
+        
         return None
 
 

--- a/fyle_slack_app/slack/events/tasks.py
+++ b/fyle_slack_app/slack/events/tasks.py
@@ -163,7 +163,7 @@ def handle_file_shared(file_id: str, user_id: str, team_id: str):
             error_message = 'Seems like something went wrong while creating an expense, please try again or contact support@fylehq.com'
             slack_client.chat_postMessage(channel=user.slack_dm_channel_id, text=error_message, thread_ts=message_ts, reply_broadcast=True)
 
-        FyleExpense(user).track_expense_creation(user, 'Expense created from uploading Receipt in Slack', expense['data'][0]['id'])
+        FyleExpense(user).track_expense_creation(user, 'Expense created from uploading Receipt in Slack', expense['id'])
         
         return None
 

--- a/fyle_slack_app/slack/interactives/tasks.py
+++ b/fyle_slack_app/slack/interactives/tasks.py
@@ -204,6 +204,8 @@ def handle_edit_expense(user: User, expense_id: str, team_id: str, view_id: str,
 
     slack_client.views_update(view=expense_form, view_id=view_id)
 
+    fyle_expense.track_expense_creation(user, 'User clicked on Complete Expense button', expense['data'][0]['id'])
+
 
 def handle_submit_report_dialog(user: User, team_id: str, report_id: str, view_id: str):
 
@@ -266,6 +268,7 @@ def handle_upsert_expense(user: User, view_id: str, team_id: str, expense_payloa
         error_message = 'Seems like something went wrong while creating an expense, please try again or contact support@fylehq.com'
         slack_client.chat_postMessage(channel=user.slack_dm_channel_id, text=error_message)
 
+    fyle_expense.track_expense_creation(user, 'Expense created from Expense Form modal in Slack', expense_id)
 
 
 def handle_feedback_submission(user: User, team_id: str, form_values: Dict, private_metadata: Dict):

--- a/fyle_slack_app/slack/interactives/tasks.py
+++ b/fyle_slack_app/slack/interactives/tasks.py
@@ -204,7 +204,7 @@ def handle_edit_expense(user: User, expense_id: str, team_id: str, view_id: str,
 
     slack_client.views_update(view=expense_form, view_id=view_id)
 
-    fyle_expense.track_expense_creation(user, 'User clicked on Complete Expense button', expense['data'][0]['id'])
+    fyle_expense.track_expense_creation(user, 'User clicked on Complete Expense button', expense['id'])
 
 
 def handle_submit_report_dialog(user: User, team_id: str, report_id: str, view_id: str):
@@ -268,7 +268,7 @@ def handle_upsert_expense(user: User, view_id: str, team_id: str, expense_payloa
         error_message = 'Seems like something went wrong while creating an expense, please try again or contact support@fylehq.com'
         slack_client.chat_postMessage(channel=user.slack_dm_channel_id, text=error_message)
 
-    fyle_expense.track_expense_creation(user, 'Expense created from Expense Form modal in Slack', expense_id)
+    fyle_expense.track_expense_creation(user, 'Expense created from Expense Form modal', expense_id)
 
 
 def handle_feedback_submission(user: User, team_id: str, form_values: Dict, private_metadata: Dict):


### PR DESCRIPTION
### Trackers
1. When user opens Expense form modal in slack -
- event name - `User opened Expense Form modal using Slack slash command`
2. When user clicks on "Add Expense" button to create an expense from expense form -
- event name - `Expense created from Expense Form modal in Slack`
3. When user clicks on "Complete Expense" button after expense creation -
- event name - `User clicked on Complete Expense button`
4. When user creates an expense from receipt -
- event name - `Expense created from uploading Receipt in Slack`