### PR TITLE
merchant suggester blocker handled

### DIFF
--- a/fyle_slack_app/slack/interactives/block_suggestion_handlers.py
+++ b/fyle_slack_app/slack/interactives/block_suggestion_handlers.py
@@ -294,8 +294,8 @@ class BlockSuggestionHandler:
 
         # Fetch all the options (choices) from Merchant expense field
         merchants_expense_field = fyle_expense.get_merchants_expense_field()
-
-        if len(merchants_expense_field['data'][0]['options']) > 0:
+        
+        if merchants_expense_field['data'] and len(merchants_expense_field['data'][0]['options']) > 0:
             suggested_merchants = merchants_expense_field['data'][0]['options']
 
         else:

--- a/fyle_slack_app/slack/interactives/block_suggestion_handlers.py
+++ b/fyle_slack_app/slack/interactives/block_suggestion_handlers.py
@@ -294,7 +294,6 @@ class BlockSuggestionHandler:
 
         # Fetch all the options (choices) from Merchant expense field
         merchants_expense_field = fyle_expense.get_merchants_expense_field()
-        
         if merchants_expense_field['data'] and len(merchants_expense_field['data'][0]['options']) > 0:
             suggested_merchants = merchants_expense_field['data'][0]['options']
 


### PR DESCRIPTION
Issue faced: while using slack bot for fyling expense form, suggestions were not visible in Merchant and category.

stack traceback:
![Screenshot from 2022-11-08 12-14-20](https://user-images.githubusercontent.com/60269359/200505854-10ff5c24-2b2d-431e-8a14-c185f4398080.png)

Problem: ```merchants_expense_field['data']``` was not returning anything and thus indexing its first element caused this IndexError.

Fix: Checking if the list contains any element, if not then move to the else block of the code